### PR TITLE
Add register number to RegisterAccessNotice.

### DIFF
--- a/src/rars/riscv/hardware/Register.java
+++ b/src/rars/riscv/hardware/Register.java
@@ -171,9 +171,8 @@ public class Register extends Observable {
     private void notifyAnyObservers(int type) {
         if (this.countObservers() > 0) {// && Globals.program != null) && Globals.program.inSteppedExecution()) {
             this.setChanged();
-            this.notifyObservers(new RegisterAccessNotice(type, this.name));
+            this.notifyObservers(new RegisterAccessNotice(type, this.name, this.number));
         }
     }
-
 
 }

--- a/src/rars/riscv/hardware/RegisterAccessNotice.java
+++ b/src/rars/riscv/hardware/RegisterAccessNotice.java
@@ -38,21 +38,30 @@ WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 
 public class RegisterAccessNotice extends AccessNotice {
     private String registerName;
+    private int registerNumber;
 
     /**
      * Constructor will be called only within this package, so assume
      * register number is in valid range.
      */
-    RegisterAccessNotice(int type, String registerName) {
+    RegisterAccessNotice(int type, String registerName, int registerNumber) {
         super(type);
         this.registerName = registerName;
+        this.registerNumber = registerNumber;
+    }
+
+    /**
+     * Fetch the register name of register accessed.
+     */
+    public String getRegisterName() {
+        return registerName;
     }
 
     /**
      * Fetch the register number of register accessed.
      */
-    public String getRegisterName() {
-        return registerName;
+    public int getRegisterNumber() {
+        return registerNumber;
     }
 
     /**


### PR DESCRIPTION
This makes the register number accessible in `RegisterAccessNotice`.

(Useful for traces, otherwise we only have access to the ABI name.)